### PR TITLE
Escape single quotes in |re regex patterns

### DIFF
--- a/sigma/backends/sqlite/sqlite.py
+++ b/sigma/backends/sqlite/sqlite.py
@@ -13,6 +13,7 @@ from sigma.conditions import (
 )
 from sigma.types import (
     SigmaCompareExpression,
+    SigmaRegularExpression,
     SigmaString,
     SpecialChars,
     SigmaCIDRExpression,
@@ -476,6 +477,12 @@ class sqliteBackend(TextQueryBackend):
             return self.quote_string(converted)
         else:
             return converted
+
+    def convert_value_re(
+        self, r: SigmaRegularExpression, state: ConversionState
+    ) -> str:
+        # Doubling single quotes is mandatory: the regex is embedded in a '...' SQL string literal.
+        return super().convert_value_re(r, state).replace("'", "''")
 
     def convert_condition_field_eq_val_str(
         self, cond: ConditionFieldEqualsValueExpression, state: ConversionState

--- a/tests/test_backend_sqlite.py
+++ b/tests/test_backend_sqlite.py
@@ -163,6 +163,27 @@ def test_sqlite_regex_query(sqlite_backend: sqliteBackend):
     )
 
 
+def test_sqlite_regex_query_single_quote(sqlite_backend: sqliteBackend):
+    assert (
+        sqlite_backend.convert(
+            SigmaCollection.from_yaml(
+                """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    fieldA|re: it's.exe
+                condition: sel
+        """
+            )
+        )
+        == ["SELECT * FROM <TABLE_NAME> WHERE fieldA REGEXP 'it''s.exe'"]
+    )
+
+
 def test_sqlite_cidr_query(sqlite_backend: sqliteBackend):
     assert (
         sqlite_backend.convert(


### PR DESCRIPTION
The re_expression template embeds the pattern in a '...' SQL string literal, but `convert_value_re` didn't double single quotes the way `convert_value_str` does. 
A regex containing a `'` (e.g. a ['\"] character class) terminated the literal early, producing invalid SQL `unrecognized token`

Fixes https://github.com/SigmaHQ/pySigma-backend-sqlite/issues/13